### PR TITLE
Update Manifestwork.tsx

### DIFF
--- a/webview-ui/src/comp/Manifestwork.tsx
+++ b/webview-ui/src/comp/Manifestwork.tsx
@@ -2,3 +2,4 @@
 /* 
 - iterate on all the managedclsuter for hub and check out for manifestwork in the namespace equil to cluster name ( oc get manifest work -n $MANAGESCLUSTER resource name )
 - than pull all manfidest work  */ 
+export {}


### PR DESCRIPTION
'Manifestwork.tsx' cannot be compiled on `npm run build` because it is not considered a module, thus failing the debug process.
Adding an empty 'export {}' statement takes care of this issue, please consider.